### PR TITLE
fix package.json URL for new repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/samcday/node-gitteh.git"
+    "url": "https://github.com/libgit2/node-gitteh.git"
   },
   "scripts": {
     "preinstall": "node-waf configure --use-bundled-libgit2",


### PR DESCRIPTION
This fixed the URL in the package.json for npm. Without this it was harder to find the project from just "npm info gitteh".

I also fixed the whitespace (tabs, spaces and mixed LF and CRLF line endings).

Thanks,
Trent
