### PR TITLE
Remove duplocate trigger_callback logic

### DIFF
--- a/src/rev_walker.cc
+++ b/src/rev_walker.cc
@@ -393,8 +393,6 @@ int RevWalker::EIO_AfterNext(eio_req *req) {
 	if(reqData->error == GIT_EREVWALKOVER) {
 		callbackArgs[0] = Undefined();
 		callbackArgs[1] = Null();
- 		TRIGGER_CALLBACK();
- 		reqData->callback.Dispose();
 	}
 	else if(reqData->error != GIT_SUCCESS) {
  		Handle<Value> error = CreateGitError(String::New("Couldn't get next commit."), reqData->error);


### PR DESCRIPTION
Fixes issue #17

TRIGGER_CALLBACK() and the resulting Dispose() was already occuring
outside the conditional. When passing a callback to walker.next(), the
callback would be triggered twice.
