### PR TITLE
require node-gyp to build properly

### DIFF
--- a/install.js
+++ b/install.js
@@ -52,10 +52,10 @@ async.series([
 	},
 	function(cb) {
 		console.log("[gitteh] Building native module.");
-		shpassthru("node-gyp configure --debug", cb);
+		shpassthru("./node_modules/.bin/node-gyp configure --debug", cb);
 	},
 	function(cb) {
-		shpassthru("node-gyp build", cb);
+		shpassthru("./node_modules/.bin/node-gyp build", cb);
 	}
 ], function(err) {
 	if(err) process.exit(err);

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   },
   "dependencies": {
     "glob": ">= 2.0.6",
-    "async": ">= 0.1.21"
+    "async": ">= 0.1.21",
+    "node-gyp": "~0.8.2"
   },
   "devDependencies": {
     "coffee-script": "~1.3.3",
-    "mocha": "~1.0.3",
-    "should": "~0.6.3",
+    "mocha": "~1.8.1",
+    "should": "~1.2.1",
     "temp": "~0.4.0",
     "wrench": "~1.3.9"
   },


### PR DESCRIPTION
to run install.js properly, it requires node-gyp, which can be installed by package.json

also bumped up mocha to suppress warning about node versions(<0.8.0)
