### PR TITLE
Fix API change of node >= 0.9.4

### DIFF
--- a/src/index.cc
+++ b/src/index.cc
@@ -98,7 +98,7 @@ namespace gitteh {
 		baton->repository_->unlockRepository();
 	}
 
-	void Index::AsyncAfterReadTree(uv_work_t *req) {
+	void Index::AsyncAfterReadTree(uv_work_t *req, int status) {
 		HandleScope scope;
 		ReadTreeBaton *baton = GetBaton<ReadTreeBaton>(req);
 
@@ -125,7 +125,7 @@ namespace gitteh {
 		AsyncLibCall(git_index_write(baton->index_->index_), baton);
 	}
 
-	void Index::AsyncAfterWrite(uv_work_t *req) {
+	void Index::AsyncAfterWrite(uv_work_t *req, int status) {
 		HandleScope scope;
 		IndexBaton *baton = GetBaton<IndexBaton>(req);
 

--- a/src/index.h
+++ b/src/index.h
@@ -25,9 +25,9 @@ namespace gitteh {
 		git_index *index_;
 
 		static void AsyncReadTree(uv_work_t*);
-		static void AsyncAfterReadTree(uv_work_t*);
+		static void AsyncAfterReadTree(uv_work_t*, int);
 		static void AsyncWrite(uv_work_t*);
-		static void AsyncAfterWrite(uv_work_t*);
+		static void AsyncAfterWrite(uv_work_t*, int);
 	};
 
 } // namespace gitteh

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -135,7 +135,7 @@ namespace gitteh {
 				baton);
 	}
 
-	void Remote::AsyncAfterUpdateTips(uv_work_t *req) {
+	void Remote::AsyncAfterUpdateTips(uv_work_t *req, int status) {
 		HandleScope scope;
 		UpdateTipsBaton *baton = GetBaton<UpdateTipsBaton>(req);
 
@@ -169,7 +169,7 @@ namespace gitteh {
 		}
 	}
 
-	void Remote::AsyncAfterConnect(uv_work_t *req) {
+	void Remote::AsyncAfterConnect(uv_work_t *req, int status) {
 		HandleScope scope;
 		ConnectBaton *baton = GetBaton<ConnectBaton>(req);
 
@@ -211,7 +211,7 @@ namespace gitteh {
 				baton->bytes, baton->stats), baton);
 	}
 
-	void Remote::AsyncAfterDownload(uv_work_t *req) {
+	void Remote::AsyncAfterDownload(uv_work_t *req, int status) {
 		HandleScope scope;
 		DownloadBaton *baton = GetBaton<DownloadBaton>(req);
 

--- a/src/remote.h
+++ b/src/remote.h
@@ -28,11 +28,11 @@ namespace gitteh {
 
 		static Handle<Value> GetStats(Local<String>, const AccessorInfo&);
 		static void AsyncUpdateTips(uv_work_t*);
-		static void AsyncAfterUpdateTips(uv_work_t*);
+		static void AsyncAfterUpdateTips(uv_work_t*, int);
 		static void AsyncConnect(uv_work_t*);
-		static void AsyncAfterConnect(uv_work_t*);
+		static void AsyncAfterConnect(uv_work_t*, int);
 		static void AsyncDownload(uv_work_t*);
-		static void AsyncAfterDownload(uv_work_t*);
+		static void AsyncAfterDownload(uv_work_t*, int);
 	};
 };
 

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -364,7 +364,7 @@ void Repository::AsyncOpenRepository(uv_work_t *req) {
 	}
 }
 
-void Repository::AsyncAfterOpenRepository(uv_work_t *req) {
+void Repository::AsyncAfterOpenRepository(uv_work_t *req, int status) {
 	HandleScope scope;
 	OpenRepoBaton *baton = GetBaton<OpenRepoBaton>(req);
 
@@ -408,7 +408,7 @@ void Repository::AsyncInitRepository(uv_work_t *req) {
 		baton->bare), baton);
 }
 
-void Repository::AsyncAfterInitRepository(uv_work_t *req) {
+void Repository::AsyncAfterInitRepository(uv_work_t *req, int status) {
 	HandleScope scope;
 	InitRepoBaton *baton = GetBaton<InitRepoBaton>(req);
 
@@ -454,7 +454,7 @@ void Repository::AsyncGetObject(uv_work_t *req) {
 	baton->repo->unlockRepository();
 }
 
-void Repository::AsyncAfterGetObject(uv_work_t *req) {
+void Repository::AsyncAfterGetObject(uv_work_t *req, int status) {
 	HandleScope scope;
 	GetObjectBaton *baton = GetBaton<GetObjectBaton>(req);
 
@@ -576,7 +576,7 @@ void Repository::AsyncCreateReference(uv_work_t *req) {
 	}
 }
 
-void Repository::AsyncReturnReference(uv_work_t *req) {
+void Repository::AsyncReturnReference(uv_work_t *req, int status) {
 	HandleScope scope;
 	ReferenceBaton *baton = GetBaton<ReferenceBaton>(req);
 
@@ -633,7 +633,7 @@ void Repository::AsyncGetRemote(uv_work_t *req) {
 		baton->name.c_str()), baton);
 }
 
-void Repository::AsyncAfterGetRemote(uv_work_t *req) {
+void Repository::AsyncAfterGetRemote(uv_work_t *req, int status) {
 	HandleScope scope;
 	GetRemoteBaton *baton = GetBaton<GetRemoteBaton>(req);
 
@@ -679,7 +679,7 @@ void Repository::AsyncCreateRemote(uv_work_t *req) {
 	}
 }
 
-void Repository::AsyncAfterCreateRemote(uv_work_t *req) {
+void Repository::AsyncAfterCreateRemote(uv_work_t *req, int status) {
 	HandleScope scope;
 	CreateRemoteBaton *baton = GetBaton<CreateRemoteBaton>(req);
 
@@ -716,7 +716,7 @@ void Repository::AsyncExists(uv_work_t *req) {
 	baton->exists = git_odb_exists(baton->repo->odb_, &baton->oid);
 }
 
-void Repository::AsyncAfterExists(uv_work_t *req) {
+void Repository::AsyncAfterExists(uv_work_t *req, int status) {
 	HandleScope scope;
 	ExistsBaton *baton = GetBaton<ExistsBaton>(req);
 

--- a/src/repository.h
+++ b/src/repository.h
@@ -47,20 +47,20 @@ private:
 	Handle<Value> wrapObject(git_object*);
 
 	static void AsyncOpenRepository(uv_work_t*);
-	static void AsyncAfterOpenRepository(uv_work_t*);
+	static void AsyncAfterOpenRepository(uv_work_t*, int);
 	static void AsyncExists(uv_work_t*);
-	static void AsyncAfterExists(uv_work_t*);
+	static void AsyncAfterExists(uv_work_t*, int);
 	static void AsyncInitRepository(uv_work_t*);
-	static void AsyncAfterInitRepository(uv_work_t*);
+	static void AsyncAfterInitRepository(uv_work_t*, int);
 	static void AsyncGetObject(uv_work_t*);
-	static void AsyncAfterGetObject(uv_work_t*);
+	static void AsyncAfterGetObject(uv_work_t*, int);
 	static void AsyncGetReference(uv_work_t*);
 	static void AsyncCreateReference(uv_work_t*);
-	static void AsyncReturnReference(uv_work_t*);
+	static void AsyncReturnReference(uv_work_t*, int);
 	static void AsyncGetRemote(uv_work_t*);
-	static void AsyncAfterGetRemote(uv_work_t*);
+	static void AsyncAfterGetRemote(uv_work_t*, int);
 	static void AsyncCreateRemote(uv_work_t*);
-	static void AsyncAfterCreateRemote(uv_work_t*);
+	static void AsyncAfterCreateRemote(uv_work_t*, int);
 
 	static Handle<Object> CreateReferenceObject(git_reference*);
 	


### PR DESCRIPTION
I added status parameters at all uv_after_cb functions for make 0.10 happier, but it makes 0.8 build fails.

I think there could be some ways for fixing this...

1) set package.json node version requirement to >= 0.9.4 or 0.10.x and guide 0.8 users to use older version of node_gitteh.
2) instead of adding parameter, use static cast(which was guided in [wiki](https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10), but I think it's bad)
3) use hell of MACROs?
