### PR TITLE
Add missing include

### DIFF
--- a/src/tag.cc
+++ b/src/tag.cc
@@ -23,6 +23,7 @@
  */
 
 #include "tag.h"
+#include "signature.h"
 
 static Persistent<String> name_symbol;
 static Persistent<String> message_symbol;


### PR DESCRIPTION
This ensures the `NativeToJS` policy for `git_signature` is declared before it's used in `tag.cc` at line 50 (`tagger` is of type `git_signature`), as recommended in the CVV8 docs.

Should fix the problem @ben was having in #42.
